### PR TITLE
fix: revert "feat: additional options when assuming roles"

### DIFF
--- a/lib/assets/aws-destination.ts
+++ b/lib/assets/aws-destination.ts
@@ -22,15 +22,4 @@ export interface AwsDestination {
    * @default - No ExternalId will be supplied
    */
   readonly assumeRoleExternalId?: string;
-
-  /**
-   * Additional options to pass to STS when assuming the role.
-   *
-   * - `RoleArn` should not be used. Use the dedicated `assumeRoleArn` property instead.
-   * - `ExternalId` should not be used. Use the dedicated `assumeRoleExternalId` instead.
-   *
-   * @see https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/STS.html#assumeRole-property
-   * @default - No additional options.
-   */
-  readonly assumeRoleAdditionalOptions?: { [key: string]: any };
 }

--- a/lib/cloud-assembly/artifact-schema.ts
+++ b/lib/cloud-assembly/artifact-schema.ts
@@ -17,17 +17,6 @@ export interface BootstrapRole {
   readonly assumeRoleExternalId?: string;
 
   /**
-   * Additional options to pass to STS when assuming the role.
-   *
-   * - `RoleArn` should not be used. Use the dedicated `arn` property instead.
-   * - `ExternalId` should not be used. Use the dedicated `assumeRoleExternalId` instead.
-   *
-   * @see https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/STS.html#assumeRole-property
-   * @default - No additional options.
-   */
-  readonly assumeRoleAdditionalOptions?: { [key: string]: any };
-
-  /**
    * Version of bootstrap stack required to use this role
    *
    * @default - No bootstrap stack required
@@ -91,17 +80,6 @@ export interface AwsCloudFormationStackProperties {
    * @default - No external ID
    */
   readonly assumeRoleExternalId?: string;
-
-  /**
-   * Additional options to pass to STS when assuming the role.
-   *
-   * - `RoleArn` should not be used. Use the dedicated `assumeRoleArn` property instead.
-   * - `ExternalId` should not be used. Use the dedicated `assumeRoleExternalId` instead.
-   *
-   * @see https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/STS.html#assumeRole-property
-   * @default - No additional options.
-   */
-  readonly assumeRoleAdditionalOptions?: { [key: string]: any };
 
   /**
    * The role that is passed to CloudFormation to execute the change set

--- a/lib/cloud-assembly/context-queries.ts
+++ b/lib/cloud-assembly/context-queries.ts
@@ -61,9 +61,65 @@ export enum ContextProvider {
 }
 
 /**
- * Options for context lookup roles.
+ * Query to AMI context provider
  */
-export interface ContextLookupRoleOptions {
+export interface AmiContextQuery {
+  /**
+   * Account to query
+   */
+  readonly account: string;
+
+  /**
+   * Region to query
+   */
+  readonly region: string;
+
+  /**
+   * The ARN of the role that should be used to look up the missing values
+   *
+   * @default - None
+   */
+  readonly lookupRoleArn?: string;
+
+  /**
+   * Owners to DescribeImages call
+   *
+   * @default - All owners
+   */
+  readonly owners?: string[];
+
+  /**
+   * Filters to DescribeImages call
+   */
+  readonly filters: { [key: string]: string[] };
+}
+
+/**
+ * Query to availability zone context provider
+ */
+export interface AvailabilityZonesContextQuery {
+  /**
+   * Query account
+   */
+  readonly account: string;
+
+  /**
+   * Query region
+   */
+  readonly region: string;
+
+  /**
+   * The ARN of the role that should be used to look up the missing values
+   *
+   * @default - None
+   */
+  readonly lookupRoleArn?: string;
+}
+
+/**
+ * Query to hosted zone context provider
+ */
+export interface HostedZoneContextQuery {
   /**
    * Query account
    */
@@ -81,51 +137,6 @@ export interface ContextLookupRoleOptions {
    */
   readonly lookupRoleArn?: string;
 
-  /**
-   * The ExternalId that needs to be supplied while assuming this role
-   *
-   * @default - No ExternalId will be supplied
-   */
-  readonly lookupRoleExternalId?: string;
-
-  /**
-   * Additional options to pass to STS when assuming the lookup role.
-   *
-   * - `RoleArn` should not be used. Use the dedicated `lookupRoleArn` property instead.
-   * - `ExternalId` should not be used. Use the dedicated `lookupRoleExternalId` instead.
-   *
-   * @see https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/STS.html#assumeRole-property
-   * @default - No additional options.
-   */
-  readonly assumeRoleAdditionalOptions?: { [key: string]: any };
-}
-
-/**
- * Query to AMI context provider
- */
-export interface AmiContextQuery extends ContextLookupRoleOptions {
-  /**
-   * Owners to DescribeImages call
-   *
-   * @default - All owners
-   */
-  readonly owners?: string[];
-
-  /**
-   * Filters to DescribeImages call
-   */
-  readonly filters: { [key: string]: string[] };
-}
-
-/**
- * Query to availability zone context provider
- */
-export interface AvailabilityZonesContextQuery extends ContextLookupRoleOptions {}
-
-/**
- * Query to hosted zone context provider
- */
-export interface HostedZoneContextQuery extends ContextLookupRoleOptions {
   /**
    * The domain name e.g. example.com to lookup
    */
@@ -152,7 +163,24 @@ export interface HostedZoneContextQuery extends ContextLookupRoleOptions {
 /**
  * Query to SSM Parameter Context Provider
  */
-export interface SSMParameterContextQuery extends ContextLookupRoleOptions {
+export interface SSMParameterContextQuery {
+  /**
+   * Query account
+   */
+  readonly account: string;
+
+  /**
+   * Query region
+   */
+  readonly region: string;
+
+  /**
+   * The ARN of the role that should be used to look up the missing values
+   *
+   * @default - None
+   */
+  readonly lookupRoleArn?: string;
+
   /**
    * Parameter name to query
    */
@@ -162,7 +190,24 @@ export interface SSMParameterContextQuery extends ContextLookupRoleOptions {
 /**
  * Query input for looking up a VPC
  */
-export interface VpcContextQuery extends ContextLookupRoleOptions {
+export interface VpcContextQuery {
+  /**
+   * Query account
+   */
+  readonly account: string;
+
+  /**
+   * Query region
+   */
+  readonly region: string;
+
+  /**
+   * The ARN of the role that should be used to look up the missing values
+   *
+   * @default - None
+   */
+  readonly lookupRoleArn?: string;
+
   /**
    * Filters to apply to the VPC
    *
@@ -204,7 +249,24 @@ export interface VpcContextQuery extends ContextLookupRoleOptions {
 /**
  * Query to endpoint service context provider
  */
-export interface EndpointServiceAvailabilityZonesContextQuery extends ContextLookupRoleOptions {
+export interface EndpointServiceAvailabilityZonesContextQuery {
+  /**
+   * Query account
+   */
+  readonly account: string;
+
+  /**
+   * Query region
+   */
+  readonly region: string;
+
+  /**
+   * The ARN of the role that should be used to look up the missing values
+   *
+   * @default - None
+   */
+  readonly lookupRoleArn?: string;
+
   /**
    * Query service name
    */
@@ -229,7 +291,7 @@ export enum LoadBalancerType {
 /**
  * Filters for selecting load balancers
  */
-export interface LoadBalancerFilter extends ContextLookupRoleOptions {
+export interface LoadBalancerFilter {
   /**
    * Filter load balancers by their type
    */
@@ -251,7 +313,24 @@ export interface LoadBalancerFilter extends ContextLookupRoleOptions {
 /**
  * Query input for looking up a load balancer
  */
-export interface LoadBalancerContextQuery extends LoadBalancerFilter {}
+export interface LoadBalancerContextQuery extends LoadBalancerFilter {
+  /**
+   * Query account
+   */
+  readonly account: string;
+
+  /**
+   * Query region
+   */
+  readonly region: string;
+
+  /**
+   * The ARN of the role that should be used to look up the missing values
+   *
+   * @default - None
+   */
+  readonly lookupRoleArn?: string;
+}
 
 /**
  * The protocol for connections from clients to the load balancer
@@ -293,6 +372,23 @@ export enum LoadBalancerListenerProtocol {
  */
 export interface LoadBalancerListenerContextQuery extends LoadBalancerFilter {
   /**
+   * Query account
+   */
+  readonly account: string;
+
+  /**
+   * Query region
+   */
+  readonly region: string;
+
+  /**
+   * The ARN of the role that should be used to look up the missing values
+   *
+   * @default - None
+   */
+  readonly lookupRoleArn?: string;
+
+  /**
    * Find by listener's arn
    * @default - does not find by listener arn
    */
@@ -314,7 +410,24 @@ export interface LoadBalancerListenerContextQuery extends LoadBalancerFilter {
 /**
  * Query input for looking up a security group
  */
-export interface SecurityGroupContextQuery extends ContextLookupRoleOptions {
+export interface SecurityGroupContextQuery {
+  /**
+   * Query account
+   */
+  readonly account: string;
+
+  /**
+   * Query region
+   */
+  readonly region: string;
+
+  /**
+   * The ARN of the role that should be used to look up the missing values
+   *
+   * @default - None
+   */
+  readonly lookupRoleArn?: string;
+
   /**
    * Security group id
    *
@@ -340,7 +453,24 @@ export interface SecurityGroupContextQuery extends ContextLookupRoleOptions {
 /**
  * Query input for looking up a KMS Key
  */
-export interface KeyContextQuery extends ContextLookupRoleOptions {
+export interface KeyContextQuery {
+  /**
+   * Query account
+   */
+  readonly account: string;
+
+  /**
+   * Query region
+   */
+  readonly region: string;
+
+  /**
+   * The ARN of the role that should be used to look up the missing values
+   *
+   * @default - None
+   */
+  readonly lookupRoleArn?: string;
+
   /**
    * Alias name used to search the Key
    */

--- a/lib/manifest.ts
+++ b/lib/manifest.ts
@@ -147,7 +147,11 @@ export class Manifest {
     return this.loadAssemblyManifest(filePath);
   }
 
-  private static validate(manifest: any, schema: jsonschema.Schema, options?: LoadManifestOptions) {
+  private static validate(
+    manifest: { version: string },
+    schema: jsonschema.Schema,
+    options?: LoadManifestOptions
+  ) {
     function parseVersion(version: string) {
       const ver = semver.valid(version);
       if (!ver) {
@@ -175,8 +179,7 @@ export class Manifest {
       nestedErrors: true,
 
       allowUnknownAttributes: false,
-      preValidateProperty: Manifest.validateAssumeRoleAdditionalOptions,
-    });
+    } as any);
 
     let errors = result.errors;
     if (options?.skipEnumCheck) {
@@ -245,34 +248,6 @@ export class Manifest {
         value: diskTag.Value,
       }))
     );
-  }
-
-  /**
-   * Validates that `assumeRoleAdditionalOptions` doesn't contain nor `ExternalId` neither `RoleArn`, as they
-   * should have dedicated properties preceding this (e.g `assumeRoleArn` and `assumeRoleExternalId`).
-   */
-  private static validateAssumeRoleAdditionalOptions(
-    instance: any,
-    key: string,
-    _schema: jsonschema.Schema,
-    _options: jsonschema.Options,
-    _ctx: jsonschema.SchemaContext
-  ) {
-    if (key !== 'assumeRoleAdditionalOptions') {
-      // note that this means that if we happen to have a property named like this, but that
-      // does want to allow 'RoleArn' or 'ExternalId', this code will have to change to consider the full schema path.
-      // I decided to make this less granular for now on purpose because it fits our needs and avoids having messy
-      // validation logic due to various schema paths.
-      return;
-    }
-
-    const assumeRoleOptions = instance[key];
-    if (assumeRoleOptions?.RoleArn) {
-      throw new Error(`RoleArn is not allowed inside '${key}'`);
-    }
-    if (assumeRoleOptions?.ExternalId) {
-      throw new Error(`ExternalId is not allowed inside '${key}'`);
-    }
   }
 
   /**

--- a/schema/assets.schema.json
+++ b/schema/assets.schema.json
@@ -97,11 +97,6 @@
                 "assumeRoleExternalId": {
                     "description": "The ExternalId that needs to be supplied while assuming this role (Default - No ExternalId will be supplied)",
                     "type": "string"
-                },
-                "assumeRoleAdditionalOptions": {
-                    "description": "Additional options to pass to STS when assuming the role.\n\n- `RoleArn` should not be used. Use the dedicated `assumeRoleArn` property instead.\n- `ExternalId` should not be used. Use the dedicated `assumeRoleExternalId` instead. (Default - No additional options.)",
-                    "type": "object",
-                    "additionalProperties": {}
                 }
             },
             "required": [
@@ -246,11 +241,6 @@
                 "assumeRoleExternalId": {
                     "description": "The ExternalId that needs to be supplied while assuming this role (Default - No ExternalId will be supplied)",
                     "type": "string"
-                },
-                "assumeRoleAdditionalOptions": {
-                    "description": "Additional options to pass to STS when assuming the role.\n\n- `RoleArn` should not be used. Use the dedicated `assumeRoleArn` property instead.\n- `ExternalId` should not be used. Use the dedicated `assumeRoleExternalId` instead. (Default - No additional options.)",
-                    "type": "object",
-                    "additionalProperties": {}
                 }
             },
             "required": [

--- a/schema/cloud-assembly.schema.json
+++ b/schema/cloud-assembly.schema.json
@@ -362,11 +362,6 @@
                     "description": "External ID to use when assuming role for cloudformation deployments (Default - No external ID)",
                     "type": "string"
                 },
-                "assumeRoleAdditionalOptions": {
-                    "description": "Additional options to pass to STS when assuming the role.\n\n- `RoleArn` should not be used. Use the dedicated `assumeRoleArn` property instead.\n- `ExternalId` should not be used. Use the dedicated `assumeRoleExternalId` instead. (Default - No additional options.)",
-                    "type": "object",
-                    "additionalProperties": {}
-                },
                 "cloudFormationExecutionRoleArn": {
                     "description": "The role that is passed to CloudFormation to execute the change set (Default - No role is passed (currently assumed role/credentials are used))",
                     "type": "string"
@@ -407,11 +402,6 @@
                 "assumeRoleExternalId": {
                     "description": "External ID to use when assuming the bootstrap role (Default - No external ID)",
                     "type": "string"
-                },
-                "assumeRoleAdditionalOptions": {
-                    "description": "Additional options to pass to STS when assuming the role.\n\n- `RoleArn` should not be used. Use the dedicated `arn` property instead.\n- `ExternalId` should not be used. Use the dedicated `assumeRoleExternalId` instead. (Default - No additional options.)",
-                    "type": "object",
-                    "additionalProperties": {}
                 },
                 "requiresBootstrapStackVersion": {
                     "description": "Version of bootstrap stack required to use this role (Default - No bootstrap stack required)",
@@ -558,6 +548,18 @@
             "description": "Query to AMI context provider",
             "type": "object",
             "properties": {
+                "account": {
+                    "description": "Account to query",
+                    "type": "string"
+                },
+                "region": {
+                    "description": "Region to query",
+                    "type": "string"
+                },
+                "lookupRoleArn": {
+                    "description": "The ARN of the role that should be used to look up the missing values (Default - None)",
+                    "type": "string"
+                },
                 "owners": {
                     "description": "Owners to DescribeImages call (Default - All owners)",
                     "type": "array",
@@ -574,27 +576,6 @@
                             "type": "string"
                         }
                     }
-                },
-                "account": {
-                    "description": "Query account",
-                    "type": "string"
-                },
-                "region": {
-                    "description": "Query region",
-                    "type": "string"
-                },
-                "lookupRoleArn": {
-                    "description": "The ARN of the role that should be used to look up the missing values (Default - None)",
-                    "type": "string"
-                },
-                "lookupRoleExternalId": {
-                    "description": "The ExternalId that needs to be supplied while assuming this role (Default - No ExternalId will be supplied)",
-                    "type": "string"
-                },
-                "assumeRoleAdditionalOptions": {
-                    "description": "Additional options to pass to STS when assuming the lookup role.\n\n- `RoleArn` should not be used. Use the dedicated `lookupRoleArn` property instead.\n- `ExternalId` should not be used. Use the dedicated `lookupRoleExternalId` instead. (Default - No additional options.)",
-                    "type": "object",
-                    "additionalProperties": {}
                 }
             },
             "required": [
@@ -618,15 +599,6 @@
                 "lookupRoleArn": {
                     "description": "The ARN of the role that should be used to look up the missing values (Default - None)",
                     "type": "string"
-                },
-                "lookupRoleExternalId": {
-                    "description": "The ExternalId that needs to be supplied while assuming this role (Default - No ExternalId will be supplied)",
-                    "type": "string"
-                },
-                "assumeRoleAdditionalOptions": {
-                    "description": "Additional options to pass to STS when assuming the lookup role.\n\n- `RoleArn` should not be used. Use the dedicated `lookupRoleArn` property instead.\n- `ExternalId` should not be used. Use the dedicated `lookupRoleExternalId` instead. (Default - No additional options.)",
-                    "type": "object",
-                    "additionalProperties": {}
                 }
             },
             "required": [
@@ -638,6 +610,18 @@
             "description": "Query to hosted zone context provider",
             "type": "object",
             "properties": {
+                "account": {
+                    "description": "Query account",
+                    "type": "string"
+                },
+                "region": {
+                    "description": "Query region",
+                    "type": "string"
+                },
+                "lookupRoleArn": {
+                    "description": "The ARN of the role that should be used to look up the missing values (Default - None)",
+                    "type": "string"
+                },
                 "domainName": {
                     "description": "The domain name e.g. example.com to lookup",
                     "type": "string"
@@ -650,27 +634,6 @@
                 "vpcId": {
                     "description": "The VPC ID to that the private zone must be associated with\n\nIf you provide VPC ID and privateZone is false, this will return no results\nand raise an error. (Default - Required if privateZone=true)",
                     "type": "string"
-                },
-                "account": {
-                    "description": "Query account",
-                    "type": "string"
-                },
-                "region": {
-                    "description": "Query region",
-                    "type": "string"
-                },
-                "lookupRoleArn": {
-                    "description": "The ARN of the role that should be used to look up the missing values (Default - None)",
-                    "type": "string"
-                },
-                "lookupRoleExternalId": {
-                    "description": "The ExternalId that needs to be supplied while assuming this role (Default - No ExternalId will be supplied)",
-                    "type": "string"
-                },
-                "assumeRoleAdditionalOptions": {
-                    "description": "Additional options to pass to STS when assuming the lookup role.\n\n- `RoleArn` should not be used. Use the dedicated `lookupRoleArn` property instead.\n- `ExternalId` should not be used. Use the dedicated `lookupRoleExternalId` instead. (Default - No additional options.)",
-                    "type": "object",
-                    "additionalProperties": {}
                 }
             },
             "required": [
@@ -683,10 +646,6 @@
             "description": "Query to SSM Parameter Context Provider",
             "type": "object",
             "properties": {
-                "parameterName": {
-                    "description": "Parameter name to query",
-                    "type": "string"
-                },
                 "account": {
                     "description": "Query account",
                     "type": "string"
@@ -699,14 +658,9 @@
                     "description": "The ARN of the role that should be used to look up the missing values (Default - None)",
                     "type": "string"
                 },
-                "lookupRoleExternalId": {
-                    "description": "The ExternalId that needs to be supplied while assuming this role (Default - No ExternalId will be supplied)",
+                "parameterName": {
+                    "description": "Parameter name to query",
                     "type": "string"
-                },
-                "assumeRoleAdditionalOptions": {
-                    "description": "Additional options to pass to STS when assuming the lookup role.\n\n- `RoleArn` should not be used. Use the dedicated `lookupRoleArn` property instead.\n- `ExternalId` should not be used. Use the dedicated `lookupRoleExternalId` instead. (Default - No additional options.)",
-                    "type": "object",
-                    "additionalProperties": {}
                 }
             },
             "required": [
@@ -719,6 +673,18 @@
             "description": "Query input for looking up a VPC",
             "type": "object",
             "properties": {
+                "account": {
+                    "description": "Query account",
+                    "type": "string"
+                },
+                "region": {
+                    "description": "Query region",
+                    "type": "string"
+                },
+                "lookupRoleArn": {
+                    "description": "The ARN of the role that should be used to look up the missing values (Default - None)",
+                    "type": "string"
+                },
                 "filter": {
                     "description": "Filters to apply to the VPC\n\nFilter parameters are the same as passed to DescribeVpcs.",
                     "type": "object",
@@ -738,27 +704,6 @@
                 "returnVpnGateways": {
                     "description": "Whether to populate the `vpnGatewayId` field of the `VpcContextResponse`,\nwhich contains the VPN Gateway ID, if one exists. You can explicitly\ndisable this in order to avoid the lookup if you know the VPC does not have\na VPN Gatway attached. (Default true)",
                     "type": "boolean"
-                },
-                "account": {
-                    "description": "Query account",
-                    "type": "string"
-                },
-                "region": {
-                    "description": "Query region",
-                    "type": "string"
-                },
-                "lookupRoleArn": {
-                    "description": "The ARN of the role that should be used to look up the missing values (Default - None)",
-                    "type": "string"
-                },
-                "lookupRoleExternalId": {
-                    "description": "The ExternalId that needs to be supplied while assuming this role (Default - No ExternalId will be supplied)",
-                    "type": "string"
-                },
-                "assumeRoleAdditionalOptions": {
-                    "description": "Additional options to pass to STS when assuming the lookup role.\n\n- `RoleArn` should not be used. Use the dedicated `lookupRoleArn` property instead.\n- `ExternalId` should not be used. Use the dedicated `lookupRoleExternalId` instead. (Default - No additional options.)",
-                    "type": "object",
-                    "additionalProperties": {}
                 }
             },
             "required": [
@@ -771,10 +716,6 @@
             "description": "Query to endpoint service context provider",
             "type": "object",
             "properties": {
-                "serviceName": {
-                    "description": "Query service name",
-                    "type": "string"
-                },
                 "account": {
                     "description": "Query account",
                     "type": "string"
@@ -787,14 +728,9 @@
                     "description": "The ARN of the role that should be used to look up the missing values (Default - None)",
                     "type": "string"
                 },
-                "lookupRoleExternalId": {
-                    "description": "The ExternalId that needs to be supplied while assuming this role (Default - No ExternalId will be supplied)",
+                "serviceName": {
+                    "description": "Query service name",
                     "type": "string"
-                },
-                "assumeRoleAdditionalOptions": {
-                    "description": "Additional options to pass to STS when assuming the lookup role.\n\n- `RoleArn` should not be used. Use the dedicated `lookupRoleArn` property instead.\n- `ExternalId` should not be used. Use the dedicated `lookupRoleExternalId` instead. (Default - No additional options.)",
-                    "type": "object",
-                    "additionalProperties": {}
                 }
             },
             "required": [
@@ -807,6 +743,18 @@
             "description": "Query input for looking up a load balancer",
             "type": "object",
             "properties": {
+                "account": {
+                    "description": "Query account",
+                    "type": "string"
+                },
+                "region": {
+                    "description": "Query region",
+                    "type": "string"
+                },
+                "lookupRoleArn": {
+                    "description": "The ARN of the role that should be used to look up the missing values (Default - None)",
+                    "type": "string"
+                },
                 "loadBalancerType": {
                     "$ref": "#/definitions/LoadBalancerType",
                     "description": "Filter load balancers by their type"
@@ -821,27 +769,6 @@
                     "items": {
                         "$ref": "#/definitions/Tag"
                     }
-                },
-                "account": {
-                    "description": "Query account",
-                    "type": "string"
-                },
-                "region": {
-                    "description": "Query region",
-                    "type": "string"
-                },
-                "lookupRoleArn": {
-                    "description": "The ARN of the role that should be used to look up the missing values (Default - None)",
-                    "type": "string"
-                },
-                "lookupRoleExternalId": {
-                    "description": "The ExternalId that needs to be supplied while assuming this role (Default - No ExternalId will be supplied)",
-                    "type": "string"
-                },
-                "assumeRoleAdditionalOptions": {
-                    "description": "Additional options to pass to STS when assuming the lookup role.\n\n- `RoleArn` should not be used. Use the dedicated `lookupRoleArn` property instead.\n- `ExternalId` should not be used. Use the dedicated `lookupRoleExternalId` instead. (Default - No additional options.)",
-                    "type": "object",
-                    "additionalProperties": {}
                 }
             },
             "required": [
@@ -862,6 +789,18 @@
             "description": "Query input for looking up a load balancer listener",
             "type": "object",
             "properties": {
+                "account": {
+                    "description": "Query account",
+                    "type": "string"
+                },
+                "region": {
+                    "description": "Query region",
+                    "type": "string"
+                },
+                "lookupRoleArn": {
+                    "description": "The ARN of the role that should be used to look up the missing values (Default - None)",
+                    "type": "string"
+                },
                 "listenerArn": {
                     "description": "Find by listener's arn (Default - does not find by listener arn)",
                     "type": "string"
@@ -896,27 +835,6 @@
                     "items": {
                         "$ref": "#/definitions/Tag"
                     }
-                },
-                "account": {
-                    "description": "Query account",
-                    "type": "string"
-                },
-                "region": {
-                    "description": "Query region",
-                    "type": "string"
-                },
-                "lookupRoleArn": {
-                    "description": "The ARN of the role that should be used to look up the missing values (Default - None)",
-                    "type": "string"
-                },
-                "lookupRoleExternalId": {
-                    "description": "The ExternalId that needs to be supplied while assuming this role (Default - No ExternalId will be supplied)",
-                    "type": "string"
-                },
-                "assumeRoleAdditionalOptions": {
-                    "description": "Additional options to pass to STS when assuming the lookup role.\n\n- `RoleArn` should not be used. Use the dedicated `lookupRoleArn` property instead.\n- `ExternalId` should not be used. Use the dedicated `lookupRoleExternalId` instead. (Default - No additional options.)",
-                    "type": "object",
-                    "additionalProperties": {}
                 }
             },
             "required": [
@@ -929,6 +847,18 @@
             "description": "Query input for looking up a security group",
             "type": "object",
             "properties": {
+                "account": {
+                    "description": "Query account",
+                    "type": "string"
+                },
+                "region": {
+                    "description": "Query region",
+                    "type": "string"
+                },
+                "lookupRoleArn": {
+                    "description": "The ARN of the role that should be used to look up the missing values (Default - None)",
+                    "type": "string"
+                },
                 "securityGroupId": {
                     "description": "Security group id (Default - None)",
                     "type": "string"
@@ -940,27 +870,6 @@
                 "vpcId": {
                     "description": "VPC ID (Default - None)",
                     "type": "string"
-                },
-                "account": {
-                    "description": "Query account",
-                    "type": "string"
-                },
-                "region": {
-                    "description": "Query region",
-                    "type": "string"
-                },
-                "lookupRoleArn": {
-                    "description": "The ARN of the role that should be used to look up the missing values (Default - None)",
-                    "type": "string"
-                },
-                "lookupRoleExternalId": {
-                    "description": "The ExternalId that needs to be supplied while assuming this role (Default - No ExternalId will be supplied)",
-                    "type": "string"
-                },
-                "assumeRoleAdditionalOptions": {
-                    "description": "Additional options to pass to STS when assuming the lookup role.\n\n- `RoleArn` should not be used. Use the dedicated `lookupRoleArn` property instead.\n- `ExternalId` should not be used. Use the dedicated `lookupRoleExternalId` instead. (Default - No additional options.)",
-                    "type": "object",
-                    "additionalProperties": {}
                 }
             },
             "required": [
@@ -972,10 +881,6 @@
             "description": "Query input for looking up a KMS Key",
             "type": "object",
             "properties": {
-                "aliasName": {
-                    "description": "Alias name used to search the Key",
-                    "type": "string"
-                },
                 "account": {
                     "description": "Query account",
                     "type": "string"
@@ -988,14 +893,9 @@
                     "description": "The ARN of the role that should be used to look up the missing values (Default - None)",
                     "type": "string"
                 },
-                "lookupRoleExternalId": {
-                    "description": "The ExternalId that needs to be supplied while assuming this role (Default - No ExternalId will be supplied)",
+                "aliasName": {
+                    "description": "Alias name used to search the Key",
                     "type": "string"
-                },
-                "assumeRoleAdditionalOptions": {
-                    "description": "Additional options to pass to STS when assuming the lookup role.\n\n- `RoleArn` should not be used. Use the dedicated `lookupRoleArn` property instead.\n- `ExternalId` should not be used. Use the dedicated `lookupRoleExternalId` instead. (Default - No additional options.)",
-                    "type": "object",
-                    "additionalProperties": {}
                 }
             },
             "required": [

--- a/test/assets.test.ts
+++ b/test/assets.test.ts
@@ -181,56 +181,6 @@ describe('File asset', () => {
   });
 });
 
-test('assumeRoleAdditionalOptions.RoleArn is validated', () => {
-  expect(() => {
-    validate({
-      version: Manifest.version(),
-      files: {
-        asset: {
-          source: {
-            path: 'a/b/c',
-          },
-          destinations: {
-            dest: {
-              region: 'us-north-20',
-              bucketName: 'Bouquet',
-              objectKey: 'key',
-              assumeRoleAdditionalOptions: {
-                RoleArn: 'foo',
-              },
-            },
-          },
-        },
-      },
-    });
-  }).toThrow(`RoleArn is not allowed inside 'assumeRoleAdditionalOptions'`);
-});
-
-test('assumeRoleAdditionalOptions.ExternalId is validated', () => {
-  expect(() => {
-    validate({
-      version: Manifest.version(),
-      files: {
-        asset: {
-          source: {
-            path: 'a/b/c',
-          },
-          destinations: {
-            dest: {
-              region: 'us-north-20',
-              bucketName: 'Bouquet',
-              objectKey: 'key',
-              assumeRoleAdditionalOptions: {
-                ExternalId: 'foo',
-              },
-            },
-          },
-        },
-      },
-    });
-  }).toThrow(`ExternalId is not allowed inside 'assumeRoleAdditionalOptions'`);
-});
-
 function validate(manifest: any) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'assets.test.'));
   const filePath = path.join(dir, 'manifest.json');

--- a/test/manifest.test.ts
+++ b/test/manifest.test.ts
@@ -2,13 +2,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as semver from 'semver';
-import {
-  ArtifactType,
-  AssemblyManifest,
-  ContextProvider,
-  Manifest,
-  StackTagsMetadataEntry,
-} from '../lib';
+import { AssemblyManifest, Manifest, StackTagsMetadataEntry } from '../lib';
 
 const FIXTURES = path.join(__dirname, 'fixtures');
 
@@ -35,102 +29,6 @@ test('manifest save', () => {
     ...assemblyManifest,
     version: Manifest.version(), // version is forced
   });
-});
-
-test('assumeRoleAdditionalOptions.RoleArn is validated in stack artifact', () => {
-  expect(() => {
-    Manifest.saveAssemblyManifest(
-      {
-        version: 'version',
-        artifacts: {
-          'aws-cdk-sqs': {
-            type: ArtifactType.AWS_CLOUDFORMATION_STACK,
-            properties: {
-              directoryName: 'dir',
-              file: 'file',
-              templateFile: 'template',
-              assumeRoleAdditionalOptions: {
-                RoleArn: 'foo',
-              },
-            },
-          },
-        },
-      },
-      'somewhere'
-    );
-  }).toThrow(`RoleArn is not allowed inside 'assumeRoleAdditionalOptions'`);
-});
-
-test('assumeRoleAdditionalOptions.ExternalId is validated in stack artifact', () => {
-  expect(() => {
-    Manifest.saveAssemblyManifest(
-      {
-        version: 'version',
-        artifacts: {
-          'aws-cdk-sqs': {
-            type: ArtifactType.AWS_CLOUDFORMATION_STACK,
-            properties: {
-              directoryName: 'dir',
-              file: 'file',
-              templateFile: 'template',
-              assumeRoleAdditionalOptions: {
-                ExternalId: 'external-id',
-              },
-            },
-          },
-        },
-      },
-      'somewhere'
-    );
-  }).toThrow(`ExternalId is not allowed inside 'assumeRoleAdditionalOptions'`);
-});
-
-test('assumeRoleAdditionalOptions.RoleArn is validated in missing context', () => {
-  expect(() => {
-    Manifest.saveAssemblyManifest(
-      {
-        version: 'version',
-        missing: [
-          {
-            key: 'key',
-            provider: ContextProvider.AMI_PROVIDER,
-            props: {
-              account: '123456789012',
-              region: 'us-east-1',
-              assumeRoleAdditionalOptions: {
-                RoleArn: 'role',
-              },
-            },
-          },
-        ],
-      },
-      'somewhere'
-    );
-  }).toThrow(`RoleArn is not allowed inside 'assumeRoleAdditionalOptions'`);
-});
-
-test('assumeRoleAdditionalOptions.ExternalId is validated in missing context', () => {
-  expect(() => {
-    Manifest.saveAssemblyManifest(
-      {
-        version: 'version',
-        missing: [
-          {
-            key: 'key',
-            provider: ContextProvider.AMI_PROVIDER,
-            props: {
-              account: '123456789012',
-              region: 'us-east-1',
-              assumeRoleAdditionalOptions: {
-                ExternalId: 'external-id',
-              },
-            },
-          },
-        ],
-      },
-      'somewhere'
-    );
-  }).toThrow(`ExternalId is not allowed inside 'assumeRoleAdditionalOptions'`);
 });
 
 test('manifest load', () => {


### PR DESCRIPTION
Merging #33 should have bumped the major version of the library, but instead it bumped the minor.

> See https://github.com/cdklabs/cloud-assembly-schema/releases/tag/v36.1.0

It shouldn't cause issues but lets revert anyway to avoid surprises while I investigate what happened. 

Reverts cdklabs/cloud-assembly-schema#33