### PR TITLE
fix: revert "feat: configure SNS topics to receive stack events on the Stack construct"

### DIFF
--- a/lib/cloud-assembly/artifact-schema.ts
+++ b/lib/cloud-assembly/artifact-schema.ts
@@ -55,13 +55,6 @@ export interface AwsCloudFormationStackProperties {
   readonly tags?: { [id: string]: string };
 
   /**
-   * SNS Notification ARNs that should receive CloudFormation Stack Events.
-   *
-   * @default - No notification arns
-   */
-  readonly notificationArns?: string[];
-
-  /**
    * The name to use for the CloudFormation stack.
    * @default - name derived from artifact ID
    */

--- a/schema/cloud-assembly.schema.json
+++ b/schema/cloud-assembly.schema.json
@@ -345,13 +345,6 @@
                         "type": "string"
                     }
                 },
-                "notificationArns": {
-                    "description": "SNS Notification ARNs that should receive CloudFormation Stack Events. (Default - No notification arns)",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
                 "stackName": {
                     "description": "The name to use for the CloudFormation stack. (Default - name derived from artifact ID)",
                     "type": "string"


### PR DESCRIPTION
For the same reason we rolled back https://github.com/cdklabs/cloud-assembly-schema/pull/33, this needs to be rolled back as well until we fix the release.

Reverts cdklabs/cloud-assembly-schema#29