### PR TITLE
chore: refactor release to store major version information in source control

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -235,24 +235,9 @@
       "steps": [
         {
           "exec": "ts-node --prefer-ts-exts -e \"require('./projenrc/update.ts').update()\""
-        }
-      ]
-    },
-    "pre-release": {
-      "name": "pre-release",
-      "env": {
-        "RELEASE": "true"
-      },
-      "steps": [
-        {
-          "exec": "ts-node --prefer-ts-exts -e \"require('./projenrc/update.ts').update()\""
         },
         {
-          "condition": "node -e \"if (process.env.CI) process.exit(1)\"",
-          "say": "✨ No changes created as a result of running pre-release or release should be committed. They will likely be reverted upon submission of the PR."
-        },
-        {
-          "exec": "yarn default"
+          "exec": "npx projen"
         }
       ]
     },
@@ -260,7 +245,8 @@
       "name": "release",
       "description": "Prepare a release from \"main\" branch",
       "env": {
-        "RELEASE": "true"
+        "RELEASE": "true",
+        "MIN_MAJOR": "36"
       },
       "steps": [
         {
@@ -276,13 +262,7 @@
           "spawn": "unbump"
         },
         {
-          "exec": "git restore package.json"
-        },
-        {
-          "exec": "git restore .projen/tasks.json"
-        },
-        {
-          "exec": "git diff --ignore-space-at-eol"
+          "exec": "git diff --ignore-space-at-eol --exit-code"
         }
       ]
     },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1,7 +1,8 @@
+// import * as fs from 'fs';
 import { JsonPatch, cdk } from 'projen';
 import { Stability } from 'projen/lib/cdk';
 import { TrailingComma } from 'projen/lib/javascript';
-import { Version } from './projenrc';
+import { MajorVersion } from './projenrc/version-bump';
 
 export const project = new cdk.JsiiProject({
   author: 'Amazon Web Services',
@@ -74,34 +75,16 @@ export const project = new cdk.JsiiProject({
   description: 'Cloud Assembly Schema',
   devDeps: ['@types/semver', 'mock-fs', 'typescript-json-schema'],
   gitignore: ['.DS_Store', '**/*.d.ts', '**/*.js'],
-  minMajorVersion: Version.bump(),
+  minMajorVersion: new MajorVersion().next,
 });
 
 const updateSchema = 'ts-node --prefer-ts-exts -e "require(\'./projenrc/update.ts\').update()"';
 
 project.preCompileTask.exec(updateSchema);
-project.addTask('pre-release', {
-  env: { RELEASE: 'true' },
-  steps: [
-    {
-      exec: updateSchema,
-    },
-    {
-      condition: `node -e "if (process.env.CI) process.exit(1)"`,
-      say: '✨ No changes created as a result of running pre-release or release should be committed. They will likely be reverted upon submission of the PR.',
-    },
-    {
-      exec: 'yarn default',
-    },
-  ],
-});
 
-project.tasks.tryFind('release')?.updateStep(4, {
-  exec: 'git restore package.json',
-});
-
-project.tasks.tryFind('release')?.exec('git restore .projen/tasks.json');
-project.tasks.tryFind('release')?.exec('git diff --ignore-space-at-eol');
+// rerun projen because the update schema task may have caused
+// the major version to change
+project.preCompileTask.exec('npx projen');
 
 const packageJson = project.tryFindObjectFile('package.json');
 packageJson?.patch(

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "post-compile": "npx projen post-compile",
     "post-upgrade": "npx projen post-upgrade",
     "pre-compile": "npx projen pre-compile",
-    "pre-release": "npx projen pre-release",
     "release": "npx projen release",
     "test": "npx projen test",
     "test:watch": "npx projen test:watch",

--- a/projenrc/update-schema.ts
+++ b/projenrc/update-schema.ts
@@ -4,10 +4,8 @@ import * as tjs from 'typescript-json-schema';
 import { SCHEMA_DIR, getGeneratedSchemaPaths, getSchemaDefinition } from './schema-definition';
 import { exec, log } from './util';
 
-export function schemasChanged(): boolean {
-  const branch = exec(['git', 'rev-parse', '--abbrev-ref', 'HEAD']);
-  exec(['git', 'fetch', 'origin', '--prune']);
-  const changes = exec(['git', 'diff', '--name-only', branch, 'remotes/origin/main']).split('\n');
+export function schemasChanged(latestTag: string): boolean {
+  const changes = exec(['git', 'diff', '--name-only', latestTag]).split('\n');
   return changes.filter((change) => getGeneratedSchemaPaths().includes(change)).length > 0;
 }
 

--- a/projenrc/version-bump.ts
+++ b/projenrc/version-bump.ts
@@ -1,41 +1,28 @@
 import * as semver from 'semver';
 import { schemasChanged } from './update-schema';
-import { exec, log } from './util';
+import { exec } from './util';
 
-export class Version {
-  public static bump() {
-    try {
-      const versionInfo = new Version();
-      if (versionInfo.changed && process.env.RELEASE) {
-        log(`✨ Updating schema version: ${versionInfo.current} -> ${versionInfo.next}`);
-        return versionInfo.nextAsInt();
-      } else if (versionInfo.changed) {
-        log(
-          `✨ This change will update the schema version: ${versionInfo.current} -> ${versionInfo.next}`
-        );
-      }
-      return undefined;
-    } catch (e) {
-      /**
-       * If git cannot be reached, returning undefined is fine. This will never happen
-       * in the release workflow and may very well happen in any given build.
-       */
-      return undefined;
+export class MajorVersion {
+  public readonly current: number;
+  public readonly next: number;
+
+  public constructor() {
+    // ensure all tags are available locally
+    exec(['git', 'fetch', '--tags']);
+    const tags = exec(['git', 'tag', '--sort=-creatordate']);
+
+    const latestTag = tags.split('\n')[0];
+    if (!latestTag.startsWith('v')) {
+      throw new Error(`Unexpected tag name: ${latestTag}`);
     }
-  }
 
-  public readonly current: string;
-  public readonly next: string;
-  public readonly changed: boolean;
+    const fullVersion = semver.parse(latestTag.substring(1));
+    if (!fullVersion) {
+      throw new Error(`Unexpected tag name: ${latestTag}`);
+    }
 
-  constructor() {
-    const tags = exec(['git', 'ls-remote', '--tags', 'origin']);
-    this.current = tags.split('/v').pop()!;
-    this.changed = schemasChanged();
-    this.next = this.changed ? semver.inc(this.current, 'major')! : this.current;
-  }
-
-  public nextAsInt() {
-    return parseInt(this.next);
+    this.current = fullVersion.major;
+    const changed = schemasChanged(latestTag);
+    this.next = changed ? fullVersion.inc('major').major : this.current;
   }
 }


### PR DESCRIPTION
This also fixes the release process to do major version bumps, which not it doesn't.