### PR TITLE
chore: remove pre-release setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,6 @@ jobs:
           node-version: 18.18.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
-      - name: Pre-Release Setup
-        run: npx projen pre-release
       - name: release
         run: npx projen release
       - name: Check if version has already been tagged

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -19,12 +19,6 @@ export const project = new cdk.JsiiProject({
   projenrcTs: true,
   docgen: false,
   stability: Stability.STABLE,
-  releaseWorkflowSetupSteps: [
-    {
-      name: 'Pre-Release Setup',
-      run: 'npx projen pre-release',
-    },
-  ],
   jsiiVersion: '*',
   keywords: ['aws', 'cdk'],
   repositoryUrl: 'https://github.com/cdklabs/cloud-assembly-schema.git',


### PR DESCRIPTION
It was removed from the projen tasks in https://github.com/cdklabs/cloud-assembly-schema/pull/55, but still existed in the workflow. 