### PR TITLE
fix: drop `engine` requirement

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18.18.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -95,7 +95,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.18.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -133,7 +133,7 @@ jobs:
           java-version: "11"
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.18.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -167,7 +167,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.18.0
+          node-version: lts/*
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -204,7 +204,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.18.0
+          node-version: lts/*
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 6.x
@@ -241,7 +241,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.18.0
+          node-version: lts/*
       - uses: actions/setup-go@v5
         with:
           go-version: ^1.18.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18.18.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -71,7 +71,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.18.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -96,7 +96,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.18.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -139,7 +139,7 @@ jobs:
           java-version: "11"
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.18.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -181,7 +181,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.18.0
+          node-version: lts/*
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -222,7 +222,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.18.0
+          node-version: lts/*
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 6.x
@@ -262,7 +262,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.18.0
+          node-version: lts/*
       - uses: actions/setup-go@v5
         with:
           go-version: ^1.18.0

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18.18.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -23,7 +23,12 @@ export const project = new cdk.JsiiProject({
   keywords: ['aws', 'cdk'],
   repositoryUrl: 'https://github.com/cdklabs/cloud-assembly-schema.git',
   homepage: 'https://github.com/cdklabs/cloud-assembly-schema',
-  minNodeVersion: '18.18.0',
+  // Don't set minNodeVersion -- this is just a library with some data and a
+  // couple of simple JS files. It doesn't care about the Node version of the
+  // consuming party at all. It's unlikely you will try to install this on a
+  // Node version it doesn't work on.
+  // minNodeVersion: '18.18.0',
+  workflowNodeVersion: 'lts/*',
   excludeTypescript: ['**/test/**/*.ts'],
   publishToMaven: {
     javaPackage: 'software.amazon.awscdk.cloudassembly.schema',

--- a/package.json
+++ b/package.json
@@ -76,9 +76,6 @@
     "aws",
     "cdk"
   ],
-  "engines": {
-    "node": ">= 18.18.0"
-  },
   "main": "lib/index.js",
   "license": "Apache-2.0",
   "homepage": "https://github.com/cdklabs/cloud-assembly-schema",


### PR DESCRIPTION
Previous versions of this library would fail to install on older Node 18's, like Node 18.17.

That's because `minNodeVersion` was set, whereas probably the intent was to set `workflowNodeVersion`.
