### PR TITLE
feat: add field for minimum CLI version

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -246,7 +246,7 @@
       "description": "Prepare a release from \"main\" branch",
       "env": {
         "RELEASE": "true",
-        "MIN_MAJOR": "38"
+        "MIN_MAJOR": "39"
       },
       "steps": [
         {

--- a/lib/cloud-assembly/schema.ts
+++ b/lib/cloud-assembly/schema.ts
@@ -117,6 +117,18 @@ export interface AssemblyManifest {
   readonly version: string;
 
   /**
+   * Required CLI version, if available
+   *
+   * If the manifest producer knows, it can put the minimum version of the CLI
+   * here that supports reading this assembly.
+   *
+   * If set, it can be used to show a more informative error message to users.
+   *
+   * @default - Minimum CLI version unknown
+   */
+  readonly minimumCliVersion?: string;
+
+  /**
    * The set of artifacts in this assembly.
    *
    * @default - no artifacts.

--- a/schema/cloud-assembly.schema.json
+++ b/schema/cloud-assembly.schema.json
@@ -9,6 +9,10 @@
                     "description": "Protocol version",
                     "type": "string"
                 },
+                "minimumCliVersion": {
+                    "description": "Required CLI version, if available\n\nIf the manifest producer knows, it can put the minimum version of the CLI\nhere that supports reading this assembly.\n\nIf set, it can be used to show a more informative error message to users. (Default - Minimum CLI version unknown)",
+                    "type": "string"
+                },
                 "artifacts": {
                     "description": "The set of artifacts in this assembly. (Default - no artifacts.)",
                     "type": "object",


### PR DESCRIPTION
This is preparing for a future feature. A Cloud Assembly producer can't yet know what CLI version would be required to read it, but in the future once we tie the Cloud Assembly package version to the CLI package version, we will be able to do that.

If we build the "check and report" feature in right now, at the time we start producing manifests with this field set, more CLI versions will be out that will be taking advantage of it, and reporting useful error messages.
