### PR TITLE
feat: reflect CLI version in error if available

### DIFF
--- a/test/fixtures/high-version-with-cli/manifest.json
+++ b/test/fixtures/high-version-with-cli/manifest.json
@@ -1,0 +1,4 @@
+{
+  "version": "99.99.99",
+  "minimumCliVersion": "minimumCliVersion",
+}

--- a/test/manifest.test.ts
+++ b/test/manifest.test.ts
@@ -156,6 +156,12 @@ test('manifest load fails on higher major version', () => {
   );
 });
 
+test('load error includes CLI error if available', () => {
+  expect(() => Manifest.loadAssemblyManifest(fixture('high-version-with-cli'))).toThrow(
+    /minimumCliVersion/
+  );
+});
+
 // once we start introducing minor version bumps that are considered
 // non breaking, this test can be removed.
 test('manifest load succeeds on higher minor version', () => {


### PR DESCRIPTION
In a recent PR, we added a field to hold the expected CLI version.

Add that information to the error message if we have it.