### PR TITLE
fix: schema validation is broken on node 16

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -115,6 +115,7 @@
     },
     {
       "name": "jsonschema",
+      "version": "~1.4.1",
       "type": "bundled"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -316,7 +316,7 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/node,@types/semver,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,jsii,jsii-diff,jsii-pacmak,jsii-rosetta,mock-fs,prettier,projen,ts-node,tsx,typescript,typescript-json-schema,jsonschema,semver"
+          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/node,@types/semver,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,jsii,jsii-diff,jsii-pacmak,jsii-rosetta,mock-fs,prettier,projen,ts-node,tsx,typescript,typescript-json-schema,semver"
         },
         {
           "exec": "yarn install --check-files"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -73,7 +73,12 @@ export const project = new cdk.JsiiProject({
     jestVersion: '29',
   },
   srcdir: 'lib',
-  bundledDeps: ['jsonschema', 'semver'],
+  bundledDeps: [
+    // restricting to minor 4 because of https://github.com/tdegrunt/jsonschema/issues/405
+    // which breaks our canaries on node 16.
+    'jsonschema@~1.4.1',
+    'semver',
+  ],
   description: 'Cloud Assembly Schema',
   devDeps: ['@types/semver', 'mock-fs', 'typescript-json-schema', 'tsx'],
   gitignore: ['.DS_Store', '**/*.d.ts', '**/*.js'],

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "typescript-json-schema": "^0.65.1"
   },
   "dependencies": {
-    "jsonschema": "^1.5.0",
+    "jsonschema": "~1.4.1",
     "semver": "^7.6.3"
   },
   "bundledDependencies": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3826,10 +3826,10 @@ jsonparse@^1.2.0:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==
 
-jsonschema@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.5.0.tgz#f6aceb1ab9123563dd901d05f81f9d4883d3b7d8"
-  integrity sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==
+jsonschema@~1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.4.1.tgz#cc4c3f0077fb4542982973d8a083b6b34f482dab"
+  integrity sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==
 
 keyv@^4.5.4:
   version "4.5.4"


### PR DESCRIPTION
Latest [upgrade](https://github.com/cdklabs/cloud-assembly-schema/pull/119) broke schema validation on node 16 because it bumped us to a faulty version of `jsonschema`. 

> See https://github.com/tdegrunt/jsonschema/issues/405
