### PR TITLE
feat: Add CC API based Context Query.  

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -249,7 +249,7 @@
       "description": "Prepare a release from \"main\" branch",
       "env": {
         "RELEASE": "true",
-        "MIN_MAJOR": "39"
+        "MIN_MAJOR": "40"
       },
       "steps": [
         {

--- a/lib/cloud-assembly/context-queries.ts
+++ b/lib/cloud-assembly/context-queries.ts
@@ -55,6 +55,11 @@ export enum ContextProvider {
   KEY_PROVIDER = 'key-provider',
 
   /**
+   * CCAPI Provider
+   */
+  CC_API_PROVIDER = 'cc-api-provider',
+
+  /**
    * A plugin provider (the actual plugin name will be in the properties)
    */
   PLUGIN = 'plugin',
@@ -348,6 +353,39 @@ export interface KeyContextQuery extends ContextLookupRoleOptions {
 }
 
 /**
+ * Query input for lookup up Cloudformation resources using CC API
+ */
+export interface CcApiContextQuery extends ContextLookupRoleOptions {
+  /**
+   * The Cloudformation resource type.
+   * See https://docs.aws.amazon.com/cloudcontrolapi/latest/userguide/supported-resources.html
+   */
+  readonly typeName: string;
+
+  /**
+   * exactIdentifier of the resource.
+   * Specifying exactIdentifier will return at most one result.
+   * Either exactIdentifier or propertyMatch should be specified.
+   * @default - None
+   */
+  readonly exactIdentifier?: string;
+
+  /**
+   * This indicates the property to search for.
+   * If both exactIdentifier and propertyMatch are specified, then exactIdentifier is used.
+   * Specifying propertyMatch will return 0 or more results.
+   * Either exactIdentifier or propertyMatch should be specified.
+   * @default - None
+   */
+  readonly propertyMatch?: Record<string, unknown>;
+
+  /**
+   * This is a set of properties returned from CC API that we want to return from ContextQuery.
+   */
+  readonly propertiesToReturn: string[];
+}
+
+/**
  * Query input for plugins
  *
  * This alternate branch is necessary because it needs to be able to escape all type checking
@@ -380,4 +418,5 @@ export type ContextQueryProperties =
   | LoadBalancerListenerContextQuery
   | SecurityGroupContextQuery
   | KeyContextQuery
+  | CcApiContextQuery
   | PluginContextQuery;

--- a/schema/cloud-assembly.schema.json
+++ b/schema/cloud-assembly.schema.json
@@ -529,6 +529,7 @@
                 "load-balancer-listener",
                 "security-group",
                 "key-provider",
+                "cc-api-provider",
                 "plugin"
             ]
         },
@@ -563,6 +564,9 @@
                 },
                 {
                     "$ref": "#/definitions/KeyContextQuery"
+                },
+                {
+                    "$ref": "#/definitions/CcApiContextQuery"
                 },
                 {
                     "$ref": "#/definitions/PluginContextQuery"
@@ -1018,6 +1022,61 @@
                 "aliasName",
                 "region"
             ]
+        },
+        "CcApiContextQuery": {
+            "description": "Query input for lookup up Cloudformation resources using CC API",
+            "type": "object",
+            "properties": {
+                "typeName": {
+                    "description": "The Cloudformation resource type.\nSee https://docs.aws.amazon.com/cloudcontrolapi/latest/userguide/supported-resources.html",
+                    "type": "string"
+                },
+                "exactIdentifier": {
+                    "description": "exactIdentifier of the resource.\nSpecifying exactIdentifier will return at most one result.\nEither exactIdentifier or propertyMatch should be specified. (Default - None)",
+                    "type": "string"
+                },
+                "propertyMatch": {
+                    "description": "This indicates the property to search for.\nIf both exactIdentifier and propertyMatch are specified, then exactIdentifier is used.\nSpecifying propertyMatch will return 0 or more results.\nEither exactIdentifier or propertyMatch should be specified. (Default - None)",
+                    "$ref": "#/definitions/Record<string,unknown>"
+                },
+                "propertiesToReturn": {
+                    "description": "This is a set of properties returned from CC API that we want to return from ContextQuery.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "account": {
+                    "description": "Query account",
+                    "type": "string"
+                },
+                "region": {
+                    "description": "Query region",
+                    "type": "string"
+                },
+                "lookupRoleArn": {
+                    "description": "The ARN of the role that should be used to look up the missing values (Default - None)",
+                    "type": "string"
+                },
+                "lookupRoleExternalId": {
+                    "description": "The ExternalId that needs to be supplied while assuming this role (Default - No ExternalId will be supplied)",
+                    "type": "string"
+                },
+                "assumeRoleAdditionalOptions": {
+                    "description": "Additional options to pass to STS when assuming the lookup role.\n\n- `RoleArn` should not be used. Use the dedicated `lookupRoleArn` property instead.\n- `ExternalId` should not be used. Use the dedicated `lookupRoleExternalId` instead. (Default - No additional options.)",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "account",
+                "propertiesToReturn",
+                "region",
+                "typeName"
+            ]
+        },
+        "Record<string,unknown>": {
+            "type": "object"
         },
         "PluginContextQuery": {
             "description": "Query input for plugins\n\nThis alternate branch is necessary because it needs to be able to escape all type checking\nwe do on on the cloud assembly -- we cannot know the properties that will be used a priori.",

--- a/schema/version.json
+++ b/schema/version.json
@@ -1,4 +1,4 @@
 {
-  "schemaHash": "bf762e5da559c685e06892ef65fdfc33d1c4bd53d4eb07d4a326d476ac58ae25",
-  "revision": 39
+  "schemaHash": "1063bafc562a50e6dafeb8664275f5d61ff631542d47992963bfaf5cf277ab6e",
+  "revision": 40
 }


### PR DESCRIPTION
Introduce CloudControl API based ContextQuery so we can use it for RDS DatabaseInstancetance.fromLookup.

This is needed for this issue: https://github.com/aws/aws-cdk/issues/31720
